### PR TITLE
changed helper to return abbreviation based on whole digits while ign…

### DIFF
--- a/addon/helpers/number-abbr.js
+++ b/addon/helpers/number-abbr.js
@@ -32,7 +32,7 @@ export function numberAbbr([number = 0, delimiter = '.', maxSignificantPlaces = 
   });
 
   const result = Ember.A(results).find( (result, index) => {
-    return number.toString().length <= (index+1)*3;
+    return parseInt(number).toString().length <= (index+1)*3;
   });
 
   return result;


### PR DESCRIPTION
…oring the fractional digits

I was passing `3898291.46666667` and getting 0Qua, so I took a look at the internals and think this makes sense.

When determining which abbreviation to use, we really only need look at the digits to the left of the decimal point (whole digits?).

I now get 3.90M which is expected
